### PR TITLE
Install development version of R Shinylive

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           packages: |
             renv
-            shinylive
+            posit-dev/r-shinylive@cf739ae
             sessioninfo
             
       - name: Install package


### PR DESCRIPTION
Hi,

Apologies for the delay in getting back to you about Shinylive. The latest version of the R Shinylive package should fix the deployment issues you were seeing. The latest version isn't on CRAN yet, but this PR will tweak things so that the development version is used to deploy your Shinylive app.

GHA log: https://github.com/georgestagg/tima-shinylive/actions/runs/11438858245/job/31825093316
Result: https://georgestagg.github.io/tima-shinylive/